### PR TITLE
PHP-138 - Allow clicking inside of the results textarea.

### DIFF
--- a/index.php
+++ b/index.php
@@ -179,7 +179,7 @@ function wpephpcompat_settings_page() {
 				<h3 style="margin: 0px;">{{plugin_name}}</h3>
 				{{#if passed}}PHP {{test_version}} compatible.{{else}}<b>Not</b> PHP {{test_version}} compatible.{{/if}}<br>
 				{{update}}<br>
-				<div class="addDetails"><textarea style="display: none;">{{logs}}</textarea><a class="view-details">view details</a></div>
+				<textarea style="display: none;">{{logs}}</textarea><a class="view-details">view details</a>
 			</div>
 			<?php $update_url = site_url( 'wp-admin/update-core.php' , 'admin' ); ?>
 			<div style="float:right;">{{#if updateAvailable}}<div class="badge wpe-update"><a href="<?php echo $update_url; ?>">Update Available</a></div>{{/if}}<div class="badge warnings">{{warnings}} Warnings</div><div class="badge errors">{{errors}} Errors</div></div>

--- a/src/js/run.js
+++ b/src/js/run.js
@@ -30,16 +30,17 @@ jQuery(document).ready(function($)
     {
         download($("#testResults").val(), "report.txt", "text/plain");
     });
-    $(document).on("click", ".addDetails", function()
+    $( document ).on( "click", ".view-details", function ()
     {
-        var textarea = $(this).children().first();
-        if (textarea.css("display") === "none")
+        // Get the textarea with is on the same (dom) level.
+        var textarea = $( this ).siblings( "textarea" );
+        if ( textarea.css( "display" ) === "none" )
         {
-            textarea.css("display", "");
+            textarea.css( "display", "" );
         }
         else
         {
-            textarea.css("display", "none");
+            textarea.css( "display", "none" );
         }
     });
     $("#runButton").on("click", function()


### PR DESCRIPTION
Currently clicking inside of the additional details box closes it, due to the way the JavaScript handler is set up. This makes it difficult to select the text.

![](https://cldup.com/vBz_ItgUuC.gif)

Fix this!
