### PR TITLE
PHP-184 - Add the parent theme if the current theme is a child.

### DIFF
--- a/src/wpephpcompat.php
+++ b/src/wpephpcompat.php
@@ -297,6 +297,15 @@ class WPEPHPCompat {
 
 			$this->add_directory( $all_themes[$k]->Name, $theme_path );
 		}
+		
+		// Add parent theme if the current theme is a child theme.
+		if ( 'yes' === $this->only_active && is_child_theme() ) {
+			$parent_theme_path = get_template_directory();
+			$theme_data        = wp_get_theme();
+			$parent_theme_name = $theme_data->parent()->Name;
+		
+			$this->add_directory( $parent_theme_name, $parent_theme_path );
+		}
 	}
 
 	/**


### PR DESCRIPTION
Reported here: 

https://wordpress.org/support/topic/only-scan-active-plugins-and-themes-scans-child-theme-but-not-parent-theme

If only scan active plugins is selected and you're using a child theme, the parent theme doesn't get scanned. This could be an issue since the parent theme's code could get executed. 

**Reviewer** 
- [x] @stevenkword 

**Screenshot**

![](https://cloudup.com/cOIe3LO23h0+)