### PR TITLE
PHP-188 - Whitelist certain plugins.

### DIFF
--- a/src/wpephpcompat.php
+++ b/src/wpephpcompat.php
@@ -58,6 +58,19 @@ class WPEPHPCompat {
 	public $base = null;
 
 	/**
+	 *  Array of "directory name" => "latest PHP version it's compatible with".
+	 *
+	 *  @todo Using the directory name is brittle, we shouldn't use it.
+	 *  @since 1.0.3
+	 *  @var array
+	 */
+	public $whitelist = array(
+		'*/jetpack/*' => '7.0', // https://github.com/wpengine/phpcompat/wiki/Results#jetpack
+		'*/wordfence/*' => '7.0', // https://github.com/wpengine/phpcompat/wiki/Results#wordfence-security
+		'*/woocommerce/*' => '7.0' // https://github.com/wpengine/phpcompat/wiki/Results#woocommerce
+	);
+
+	/**
 	 * @param string $dir Base plugin directory.
 	 */
 	function __construct( $dir ) {
@@ -209,7 +222,9 @@ class WPEPHPCompat {
 		$this->values['standard']    = 'PHPCompatibility';
 		$this->values['reportWidth'] = '9999';
 		$this->values['extensions']  = array( 'php' );
-		$this->values['ignored'] = array( '*/tests/*', '*/jetpack/modules/*', '*/node_modules/*', '*/tmp/*' );
+
+		// Whitelist.
+		$this->values['ignored'] = $this->generate_ignored_list();
 
 		PHP_CodeSniffer::setConfigData( 'testVersion', $this->test_version, true );
 
@@ -220,6 +235,30 @@ class WPEPHPCompat {
 		$report = ob_get_clean();
 
 		return $this->clean_report( $report );
+	}
+	
+	/**
+	 * Generate a list of ignored files and directories.
+	 *
+	 * @since 1.0.3
+	 * @return array An array containing files and directories that should be ignored.
+	 */
+	public function generate_ignored_list() {
+		// Default ignored list.
+		$ignored = array(
+			'*/tests/*', // No reason to scan tests.
+			'*/node_modules/*', // Commonly used for development but not in production.
+			'*/tmp/*', // Temporary files.
+		);
+		
+		foreach ( $this->whitelist as $plugin => $version ) {
+			// Check to see if the plugin is compatible with the tested version.
+			if ( version_compare( $this->test_version, $version, '<=' ) ) {
+				array_push( $ignored, $plugin );
+			}
+		}
+		
+		return $ignored;
 	}
 
 	/**

--- a/src/wpephpcompat.php
+++ b/src/wpephpcompat.php
@@ -67,7 +67,8 @@ class WPEPHPCompat {
 	public $whitelist = array(
 		'*/jetpack/*' => '7.0', // https://github.com/wpengine/phpcompat/wiki/Results#jetpack
 		'*/wordfence/*' => '7.0', // https://github.com/wpengine/phpcompat/wiki/Results#wordfence-security
-		'*/woocommerce/*' => '7.0' // https://github.com/wpengine/phpcompat/wiki/Results#woocommerce
+		'*/woocommerce/*' => '7.0', // https://github.com/wpengine/phpcompat/wiki/Results#woocommerce
+		'*/wp-migrate-db/*' => '7.0', // https://github.com/wpengine/phpcompat/wiki/Results#wp-migrate-db
 	);
 
 	/**

--- a/tests/phpunit/test_generate_ignored_list.php
+++ b/tests/phpunit/test_generate_ignored_list.php
@@ -1,0 +1,73 @@
+<?php 
+class TestGenerateIgnoredList extends WP_UnitTestCase {
+	
+	private $wpephpc;
+	
+	public function setUp()
+	{
+		$root_dir = realpath( __DIR__ . '/../../' );
+
+		$this->wpephpc = new \WPEPHPCompat( $root_dir );
+		
+		$this->wpephpc->whitelist = array(
+			'*/jetpack/*' => '7.0',
+			'*/fakeplugin/*' => '5.3',
+			'*/reallyfake/*' => '5.5',
+			'*/oldplugin/*' => '5.2',
+		);
+	}
+
+	function test_generate_ignored_list_default() {
+		$this->wpephpc->test_version = '7.0';
+		
+		$ignored = $this->wpephpc->generate_ignored_list();
+		
+		$this->assertContains( '*/tests/*', $ignored );
+		$this->assertContains( '*/tmp/*', $ignored );
+	}
+	
+	function test_generate_ignored_list_version_70() {
+		$this->wpephpc->test_version = '7.0';
+		
+		$ignored = $this->wpephpc->generate_ignored_list();
+		
+		$this->assertContains( '*/jetpack/*', $ignored );
+		$this->assertNotContains( '*/fakeplugin/*', $ignored );
+		$this->assertNotContains( '*/reallyfake/*', $ignored );
+		$this->assertNotContains( '*/oldplugin/*', $ignored );
+
+	}
+	
+	function test_generate_ignored_list_version_71() {
+		$this->wpephpc->test_version = '7.1';
+		
+		$ignored = $this->wpephpc->generate_ignored_list();
+		
+		$this->assertNotContains( '*/jetpack/*', $ignored );
+		$this->assertNotContains( '*/fakeplugin/*', $ignored );
+		$this->assertNotContains( '*/reallyfake/*', $ignored );
+		$this->assertNotContains( '*/oldplugin/*', $ignored );
+	}
+	
+	function test_generate_ignored_list_version_53() {
+		$this->wpephpc->test_version = '5.3';
+		
+		$ignored = $this->wpephpc->generate_ignored_list();
+		
+		$this->assertContains( '*/jetpack/*', $ignored );
+		$this->assertContains( '*/fakeplugin/*', $ignored );
+		$this->assertContains( '*/reallyfake/*', $ignored );
+		$this->assertNotContains( '*/oldplugin/*', $ignored );
+	}
+	
+	function test_generate_ignored_list_version_55() {
+		$this->wpephpc->test_version = '5.5';
+		
+		$ignored = $this->wpephpc->generate_ignored_list();
+		
+		$this->assertContains( '*/jetpack/*', $ignored );
+		$this->assertContains( '*/reallyfake/*', $ignored );
+		$this->assertNotContains( '*/fakeplugin/*', $ignored );
+		$this->assertNotContains( '*/oldplugin/*', $ignored );
+	}
+}


### PR DESCRIPTION
This PR adds a way to whitelist plugins/themes for certain PHP versions. The idea is to test popular plugins manually and review the results and whitelist them as we go. The results can be found here: 

https://github.com/wpengine/phpcompat/wiki/Results