### PR TITLE
Add and use fixJSONResponse.

### DIFF
--- a/src/js/run.js
+++ b/src/js/run.js
@@ -72,7 +72,7 @@ function checkStatus() {
 	var obj;
 	jQuery.post( ajaxurl, data, function( response ) {
 		try {
-			obj = JSON.parse( response );
+			obj = JSON.parse( fixJSONResponse( response ) );
 		} catch(e) {
 			// If response wasn't JSON something is wrong.
 			alert( "Error: " + e + "\nResponse: " + response );
@@ -237,4 +237,17 @@ function displayReport( response ) {
 
 		$( '#standardMode' ).prepend( '<h3>Your WordPress install is not PHP ' + test_version + ' compatible.</h3>' );
 	}
+}
+
+
+/**
+ * Strip elements from an Ajax call to help with JSON parsing.
+ *
+ * @param {string} string Ajax response to attempt to fix.
+ * @returns {string} Fixed Ajax response.
+ */
+function fixJSONResponse( response ) {
+	
+	// The goal here is to match anything before the opening {", and remove it.
+	return response.replace( /((.|\n|\r)+?){"/gm, "{\"" );
 }

--- a/tests/qunit/test-run.js
+++ b/tests/qunit/test-run.js
@@ -189,3 +189,32 @@ QUnit.test( 'Test checkStatus fail JSON.parse', function( assert ) {
 
 	checkStatus();
 });
+
+QUnit.module( 'fixJSONResponse' );
+
+QUnit.test( 'Test fixJSONResponse with errors.', function( assert ) {
+	assert.expect( 1 );
+	var json = '{"status":"1","count":"17","total":"17","progress":100,"results":"done"}';
+	var response = "Error: This is an error\n\n\n\n\r\r\tNotice: This is a notice\n\n\r" + json;
+	
+	try {
+		obj = JSON.parse( fixJSONResponse( response ) );
+		assert.strictEqual( typeof obj, 'object', 'Response was parsed.');
+	} catch(e) {
+		
+	}
+});
+
+QUnit.test( 'Test fixJSONResponse with no errors.', function( assert ) {
+	assert.expect( 2 );
+	var json = '{"status":"1","count":"17","total":"17","progress":100,"results":"done"}';
+	
+	try {
+		response = fixJSONResponse( json );
+		obj = JSON.parse( fixJSONResponse( response ) );
+		assert.strictEqual( typeof obj, 'object', 'Response was parsed.');
+		assert.strictEqual( json, response, 'Response is equal to json.');
+	} catch(e) {
+		
+	}
+});


### PR DESCRIPTION
If a site is generating errors/notices, these can mess up the Ajax response from the server. This PR uses regex to remove anything before the JSON. 
