### PR TITLE
Improvement of cli detection - fixing apostrophe

### DIFF
--- a/src/wpephpcompat.php
+++ b/src/wpephpcompat.php
@@ -463,7 +463,7 @@ class WPEPHPCompat {
 	 * @return boolean Returns true if the request came from the command line.
 	 */
 	private function is_command_line() {
-		return defined( 'WP_CLI' ) || defined( 'PHPUNIT_TEST' )  || php_sapi_name() == ‘cli’;
+		return defined( 'WP_CLI' ) || defined( 'PHPUNIT_TEST' ) || php_sapi_name() == 'cli';
 	}
 
 	/**


### PR DESCRIPTION
Sorry for mistake,

I just saw when I done copy/paste, it's copied wrong character. I saw it in last (today's) update when I checked code again. It's strange because travis checking is passed.

Sasa