### PR TITLE
Update CodeSniffer version to 2.8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
 		"email": "jason@stallin.gs"
 	}],
 	"require": {
-		"squizlabs/php_codesniffer": "2.6.*",
+		"squizlabs/php_codesniffer": "2.8.*",
 		"wimg/php-compatibility": "dev-master",
 		"simplyadmire/composer-plugins" : "@dev"
 	},

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "825eb05a423f2198dc6ba3edab9b8a90",
-    "content-hash": "b619faca99011b13200eb285642e4302",
+    "content-hash": "92c630099ff763fc107c4e9a552b0e66",
     "packages": [
         {
             "name": "simplyadmire/composer-plugins",
@@ -58,20 +57,20 @@
                 "typo3"
             ],
             "abandoned": true,
-            "time": "2016-05-12 11:58:38"
+            "time": "2016-05-12T11:58:38+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "2.6.2",
+            "version": "2.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "4edb770cb853def6e60c93abb088ad5ac2010c83"
+                "reference": "d7cf0d894e8aa4c73712ee4a331cc1eaa37cdc7d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/4edb770cb853def6e60c93abb088ad5ac2010c83",
-                "reference": "4edb770cb853def6e60c93abb088ad5ac2010c83",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/d7cf0d894e8aa4c73712ee4a331cc1eaa37cdc7d",
+                "reference": "d7cf0d894e8aa4c73712ee4a331cc1eaa37cdc7d",
                 "shasum": ""
             },
             "require": {
@@ -136,7 +135,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2016-07-13 23:29:13"
+            "time": "2017-03-01T22:17:45+00:00"
         },
         {
             "name": "wimg/php-compatibility",
@@ -183,7 +182,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2017-01-03 20:31:50"
+            "time": "2017-01-03T20:31:50+00:00"
         }
     ],
     "packages-dev": [
@@ -235,7 +234,7 @@
                 "dev",
                 "scripts"
             ],
-            "time": "2015-11-12 17:00:24"
+            "time": "2015-11-12T17:00:24+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",
@@ -271,7 +270,7 @@
                 "standards",
                 "wordpress"
             ],
-            "time": "2016-08-29 20:04:47"
+            "time": "2016-08-29T20:04:47+00:00"
         }
     ],
     "aliases": [],


### PR DESCRIPTION
Updating the CodeSniffer version to 2.8.1. Tested this by creating a zip of this plugin and testing on my comp account against a few plugins.