### PR TITLE
Add Genesis to Whitelist

### DIFF
--- a/src/wpephpcompat.php
+++ b/src/wpephpcompat.php
@@ -92,7 +92,7 @@ class WPEPHPCompat {
 		'*/woocommerce-pdf-invoices-packing-slips/*'      => '7.0', // https://github.com/wpengine/phpcompat/issues/160
 		'*/iwp-client/*'                                  => '7.0', // https://wordpress.org/support/topic/iwp-client-and-php-7-compatibility/
 		'*/health-check/*'                                => '7.2', // https://github.com/wpengine/phpcompat/issues/179
-		'*/genesis/*'                                     => '7.2', // https://github.com/wpengine/phpcompat/issues/127
+		'*/genesis/'                                     => '7.2', // https://github.com/wpengine/phpcompat/issues/127
 	);
 
 	/**

--- a/src/wpephpcompat.php
+++ b/src/wpephpcompat.php
@@ -92,6 +92,7 @@ class WPEPHPCompat {
 		'*/woocommerce-pdf-invoices-packing-slips/*'      => '7.0', // https://github.com/wpengine/phpcompat/issues/160
 		'*/iwp-client/*'                                  => '7.0', // https://wordpress.org/support/topic/iwp-client-and-php-7-compatibility/
 		'*/health-check/*'                                => '7.2', // https://github.com/wpengine/phpcompat/issues/179
+		'*/genesis/*'                                     => '7.2', // https://github.com/wpengine/phpcompat/issues/127
 	);
 
 	/**

--- a/src/wpephpcompat.php
+++ b/src/wpephpcompat.php
@@ -92,7 +92,7 @@ class WPEPHPCompat {
 		'*/woocommerce-pdf-invoices-packing-slips/*'      => '7.0', // https://github.com/wpengine/phpcompat/issues/160
 		'*/iwp-client/*'                                  => '7.0', // https://wordpress.org/support/topic/iwp-client-and-php-7-compatibility/
 		'*/health-check/*'                                => '7.2', // https://github.com/wpengine/phpcompat/issues/179
-		'*/genesis/'                                     => '7.2', // https://github.com/wpengine/phpcompat/issues/127
+		'*/genesis/*'                                     => '7.2', // https://github.com/wpengine/phpcompat/issues/127
 	);
 
 	/**


### PR DESCRIPTION
This commit addresses concerns regarding warnings being thrown by the Genesis Framework about using double underscore prefixes on function names as reported in https://github.com/wpengine/phpcompat/issues/127 

I don't see a dev branch so please let me know if I need to change the branch to merge into. I've confirmed that Genesis (up to 2.7.0-dev) works on PHP 7.2.