### PR TITLE
Whitelist WPMU DEV Dashboard plugin

### DIFF
--- a/src/wpephpcompat.php
+++ b/src/wpephpcompat.php
@@ -93,6 +93,7 @@ class WPEPHPCompat {
 		'*/iwp-client/*'                                  => '7.0', // https://wordpress.org/support/topic/iwp-client-and-php-7-compatibility/
 		'*/health-check/*'                                => '7.2', // https://github.com/wpengine/phpcompat/issues/179
 		'*/genesis/*'                                     => '7.2', // https://github.com/wpengine/phpcompat/issues/127
+		'*/wpmudev-updates/*'                             => '7.3', // https://github.com/wpengine/phpcompat/issues/178
 	);
 
 	/**


### PR DESCRIPTION
Fixes #178 
https://github.com/wpengine/phpcompat/issues/178

I'm the developer of the plugin, the lines in question are for backwards compatibility though PHP version 5.2. Confirmed working through 7.3 on hundreds of thousands of sites.