### PR TITLE
Add PHP 7.3 Compatability Checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,10 @@ matrix:
       env: WP_VERSION=latest WP_MULTISITE=1
     - php: 7.3
       env: NPM_TESTS=1
+  exclude:
+    - php: 7.3
+      env: WP_VERSION=4.5
+
 
 before_script:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,11 @@
 sudo: false
 language: php
 php:
-  - 5.4
-  - 5.5
   - 5.6
   - 7.0
   - 7.1
   - 7.2
+  - 7.3
 env:
   - WP_VERSION=latest
   - WP_VERSION=4.5
@@ -14,22 +13,22 @@ dist: trusty
 matrix:
   include:
     - php: 5.2
-      env: WP_VERSION=latest
-      dist: precise
-    - php: 5.2
-      env: WP_VERSION=4.5
+      env: WP_VERSION=5.1
       dist: precise
     - php: 5.3
-      env: WP_VERSION=latest
+      env: WP_VERSION=5.1
       dist: precise
-    - php: 5.3
-      env: WP_VERSION=4.5
+    - php: 5.4
+      env: WP_VERSION=5.1
       dist: precise
-    - php: 5.6
+    - php: 5.5
+      env: WP_VERSION=5.1
+      dist: precise
+    - php: 7.3
       env: WP_VERSION=latest WP_MULTISITE=1
-    - php: 5.6
+    - php: 7.3
       env: WP_VERSION=4.5 WP_MULTISITE=1
-    - php: 7.0
+    - php: 7.3
       env: NPM_TESTS=1
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,10 +24,12 @@ matrix:
     - php: 5.5
       env: WP_VERSION=5.1
       dist: precise
+    - php: 5.6
+      env: WP_VERSION=5.1 WP_MULTISITE=1
+    - php: 7.3
+      env: WP_VERSION=5.2 WP_MULTISITE=1
     - php: 7.3
       env: WP_VERSION=latest WP_MULTISITE=1
-    - php: 7.3
-      env: WP_VERSION=4.5 WP_MULTISITE=1
     - php: 7.3
       env: NPM_TESTS=1
 

--- a/composer.json
+++ b/composer.json
@@ -7,12 +7,12 @@
 		"email": "jason@stallin.gs"
 	}],
 	"require": {
-		"squizlabs/php_codesniffer": "^2.9.1",
+		"squizlabs/php_codesniffer": "^2.9.2",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
-		"phpcompatibility/phpcompatibility-wp": "^1"
+		"phpcompatibility/phpcompatibility-wp": "^2"
 	},
 	"require-dev": {
-		"wp-coding-standards/wpcs": "dev-master"
+		"wp-coding-standards/wpcs": "^1"
 	},
 	"scripts": {
 		"post-update-cmd": [

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,11 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "f5c5c87be3a4f3dc0bdf79ffcb31e30e",
+    "hash": "6f3f111cee87df2a6b762e6eeade451e",
+    "content-hash": "444578a8dfe80cf6550e1434f655d2e6",
     "packages": [
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
@@ -72,20 +73,20 @@
                 "stylecheck",
                 "tests"
             ],
-            "time": "2017-12-06T16:27:17+00:00"
+            "time": "2017-12-06 16:27:17"
         },
         {
             "name": "phpcompatibility/php-compatibility",
-            "version": "8.2.0",
+            "version": "9.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
-                "reference": "eaf613c1a8265bcfd7b0ab690783f2aef519f78a"
+                "reference": "3db1bf1e28123fd574a4ae2e9a84072826d51b5e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/eaf613c1a8265bcfd7b0ab690783f2aef519f78a",
-                "reference": "eaf613c1a8265bcfd7b0ab690783f2aef519f78a",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/3db1bf1e28123fd574a4ae2e9a84072826d51b5e",
+                "reference": "3db1bf1e28123fd574a4ae2e9a84072826d51b5e",
                 "shasum": ""
             },
             "require": {
@@ -99,53 +100,61 @@
                 "phpunit/phpunit": "~4.5 || ^5.0 || ^6.0 || ^7.0"
             },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",
                 "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
             },
             "type": "phpcodesniffer-standard",
-            "autoload": {
-                "psr-4": {
-                    "PHPCompatibility\\": "PHPCompatibility/"
-                }
-            },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "LGPL-3.0-or-later"
             ],
             "authors": [
                 {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCompatibility/PHPCompatibility/graphs/contributors"
+                },
+                {
                     "name": "Wim Godden",
+                    "homepage": "https://github.com/wimg",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
                     "role": "lead"
                 }
             ],
-            "description": "A set of sniffs for PHP_CodeSniffer that checks for PHP version compatibility.",
+            "description": "A set of sniffs for PHP_CodeSniffer that checks for PHP cross-version compatibility.",
             "homepage": "http://techblog.wimgodden.be/tag/codesniffer/",
             "keywords": [
                 "compatibility",
                 "phpcs",
                 "standards"
             ],
-            "time": "2018-07-17T13:42:26+00:00"
+            "time": "2019-06-27 19:58:56"
         },
         {
-            "name": "phpcompatibility/phpcompatibility-wp",
-            "version": "1.0.0",
+            "name": "phpcompatibility/phpcompatibility-paragonie",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/PHPCompatibility/PHPCompatibilityWP.git",
-                "reference": "b26c84df3ec1d4850d0f22264a4a16482a171996"
+                "url": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie.git",
+                "reference": "9160de79fcd683b5c99e9c4133728d91529753ea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/b26c84df3ec1d4850d0f22264a4a16482a171996",
-                "reference": "b26c84df3ec1d4850d0f22264a4a16482a171996",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/9160de79fcd683b5c99e9c4133728d91529753ea",
+                "reference": "9160de79fcd683b5c99e9c4133728d91529753ea",
                 "shasum": ""
             },
             "require": {
-                "phpcompatibility/php-compatibility": "^8.1"
+                "phpcompatibility/php-compatibility": "^9.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4"
             },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
                 "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
             },
             "type": "phpcodesniffer-standard",
@@ -163,7 +172,58 @@
                     "role": "lead"
                 }
             ],
-            "description": "A set of sniffs for PHP_CodeSniffer that checks for PHP version compatibility for WordPress projects.",
+            "description": "A set of rulesets for PHP_CodeSniffer to check for PHP cross-version compatibility issues in projects, while accounting for polyfills provided by the Paragonie polyfill libraries.",
+            "homepage": "http://phpcompatibility.com/",
+            "keywords": [
+                "compatibility",
+                "paragonie",
+                "phpcs",
+                "polyfill",
+                "standards"
+            ],
+            "time": "2018-12-16 19:10:44"
+        },
+        {
+            "name": "phpcompatibility/phpcompatibility-wp",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibilityWP.git",
+                "reference": "cb303f0067cd5b366a41d4fb0e254fb40ff02efd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/cb303f0067cd5b366a41d4fb0e254fb40ff02efd",
+                "reference": "cb303f0067cd5b366a41d4fb0e254fb40ff02efd",
+                "shasum": ""
+            },
+            "require": {
+                "phpcompatibility/php-compatibility": "^9.0",
+                "phpcompatibility/phpcompatibility-paragonie": "^1.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "lead"
+                }
+            ],
+            "description": "A ruleset for PHP_CodeSniffer to check for PHP cross-version compatibility issues in projects, while accounting for polyfills provided by WordPress.",
             "homepage": "http://phpcompatibility.com/",
             "keywords": [
                 "compatibility",
@@ -171,20 +231,20 @@
                 "standards",
                 "wordpress"
             ],
-            "time": "2018-07-16T22:10:02+00:00"
+            "time": "2018-10-07 18:31:37"
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "2.9.1",
+            "version": "2.9.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "dcbed1074f8244661eecddfc2a675430d8d33f62"
+                "reference": "2acf168de78487db620ab4bc524135a13cfe6745"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/dcbed1074f8244661eecddfc2a675430d8d33f62",
-                "reference": "dcbed1074f8244661eecddfc2a675430d8d33f62",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/2acf168de78487db620ab4bc524135a13cfe6745",
+                "reference": "2acf168de78487db620ab4bc524135a13cfe6745",
                 "shasum": ""
             },
             "require": {
@@ -249,30 +309,33 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2017-05-22T02:43:20+00:00"
+            "time": "2018-11-07 22:31:41"
         }
     ],
     "packages-dev": [
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "dev-master",
+            "version": "1.2.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git",
-                "reference": "cf6b310caad735816caef7573295f8a534374706"
+                "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
+                "reference": "f328bcafd97377e8e5e5d7b244d5ddbf301a3a5c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress-Coding-Standards/WordPress-Coding-Standards/zipball/cf6b310caad735816caef7573295f8a534374706",
-                "reference": "cf6b310caad735816caef7573295f8a534374706",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/f328bcafd97377e8e5e5d7b244d5ddbf301a3a5c",
+                "reference": "f328bcafd97377e8e5e5d7b244d5ddbf301a3a5c",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3",
                 "squizlabs/php_codesniffer": "^2.9.0 || ^3.0.2"
             },
+            "require-dev": {
+                "phpcompatibility/php-compatibility": "^9.0"
+            },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3"
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
             },
             "type": "phpcodesniffer-standard",
             "notification-url": "https://packagist.org/downloads/",
@@ -291,14 +354,12 @@
                 "standards",
                 "wordpress"
             ],
-            "time": "2018-02-16T01:57:48+00:00"
+            "time": "2018-12-18 09:43:51"
         }
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "wp-coding-standards/wpcs": 20
-    },
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": [],

--- a/php52/composer.lock
+++ b/php52/composer.lock
@@ -1,23 +1,24 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
+    "hash": "7c46dfad96b04e3adea69f7f0c3f9cdd",
     "content-hash": "937367a108bb97c748a6156b5d542002",
     "packages": [
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "2.9.1",
+            "version": "2.9.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "dcbed1074f8244661eecddfc2a675430d8d33f62"
+                "reference": "2acf168de78487db620ab4bc524135a13cfe6745"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/dcbed1074f8244661eecddfc2a675430d8d33f62",
-                "reference": "dcbed1074f8244661eecddfc2a675430d8d33f62",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/2acf168de78487db620ab4bc524135a13cfe6745",
+                "reference": "2acf168de78487db620ab4bc524135a13cfe6745",
                 "shasum": ""
             },
             "require": {
@@ -82,7 +83,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2017-05-22T02:43:20+00:00"
+            "time": "2018-11-07 22:31:41"
         },
         {
             "name": "wimg/php-compatibility",
@@ -126,7 +127,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2017-07-15T23:03:53+00:00"
+            "time": "2017-07-15 23:03:53"
         },
         {
             "name": "xrstf/composer-php52",
@@ -157,7 +158,7 @@
             "license": [
                 "MIT"
             ],
-            "time": "2016-04-16T21:52:24+00:00"
+            "time": "2016-04-16 21:52:24"
         }
     ],
     "packages-dev": [],

--- a/readme.md
+++ b/readme.md
@@ -2,8 +2,8 @@
 **Contributors:** [wpengine](https://profiles.wordpress.org/wpengine), [octalmage](https://profiles.wordpress.org/octalmage), [stevenkword](https://profiles.wordpress.org/stevenkword), [Taylor4484](https://profiles.wordpress.org/Taylor4484), [pross](https://profiles.wordpress.org/pross), [jcross](https://profiles.wordpress.org/jcross)
 **Tags:** php 7, php 5.5, php, version, compatibility, checker, wp engine, wpe, wpengine
 **Requires at least:** 3.5
-**Tested up to:** 5.0
-**Stable tag:** 1.4.8
+**Tested up to:** 5.2.2
+**Stable tag:** 1.5.0
 **License:** GPLv2 or later
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -21,11 +21,11 @@ This plugin will lint theme and plugin code inside your WordPress file system an
 
 **This plugin relies on WP-Cron to scan files in the background. The scan will get stuck if the site's WP-Cron isn't running correctly. Please see the [FAQ](https://wordpress.org/plugins/php-compatibility-checker/faq/) for more information.**
 
-### Update to PHP 7.2 ###
-* Use this plugin to check your site for compatibility up to PHP 7.2!
-* As of [December 2018](https://wordpress.org/about/stats/), 24.9% of WordPress websites run a PHP version older than PHP 5.6.
+### Update to PHP 7.3 ###
+* Use this plugin to check your site for compatibility up to PHP 7.3!
+* As of [July 2019](https://wordpress.org/about/stats/), 20.1% of WordPress websites run a PHP version older than PHP 5.6.
 * These versions of PHP have been [deprecated and unsupported](https://secure.php.net/supported-versions.php) for over 2 years.
-* Only 38.8% of WordPress websites run PHP 7, the current main version of PHP.
+* Only 54.1% of WordPress websites run PHP 7, the current main version of PHP.
 
 
 ### Disclaimer ###
@@ -117,6 +117,9 @@ To disclose security issues for this plugin please email WordPress@wpengine.com
 
 
 ## Changelog ##
+### 1.5.0 ###
+- Added support for PHP 7.3 compatibility checks
+
 ### 1.4.8 ###
 - Update dependencies.
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: wpengine, octalmage, stevenkword, Taylor4484, pross, jcross
 Tags: php 7, php 5.5, php, version, compatibility, checker, wp engine, wpe, wpengine
 Requires at least: 3.5
-Tested up to: 5.0
-Stable tag: 1.4.8
+Tested up to: 5.2.2
+Stable tag: 1.5.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -21,11 +21,11 @@ This plugin will lint theme and plugin code inside your WordPress file system an
 
 **This plugin relies on WP-Cron to scan files in the background. The scan will get stuck if the site's WP-Cron isn't running correctly. Please see the [FAQ](https://wordpress.org/plugins/php-compatibility-checker/faq/) for more information.**
 
-= Update to PHP 7.2 =
-* Use this plugin to check your site for compatibility up to PHP 7.2!
-* As of [December 2018](https://wordpress.org/about/stats/), 24.9% of WordPress websites run a PHP version older than PHP 5.6.
+= Update to PHP 7.3 =
+* Use this plugin to check your site for compatibility up to PHP 7.3!
+* As of [July 2019](https://wordpress.org/about/stats/), 20.1% of WordPress websites run a PHP version older than PHP 5.6.
 * These versions of PHP have been [deprecated and unsupported](https://secure.php.net/supported-versions.php) for over 2 years.
-* Only 38.8% of WordPress websites run PHP 7, the current main version of PHP.
+* Only 54.1% of WordPress websites run PHP 7, the current main version of PHP.
 
 
 = Disclaimer =
@@ -113,6 +113,9 @@ To disclose security issues for this plugin please email WordPress@wpengine.com
 2. Compatibility results screen
 
 == Changelog ==
+= 1.5.0 =
+- Added support for PHP 7.3 compatibility checks
+
 = 1.4.8 =
 - Update dependencies.
 

--- a/src/wpcli.php
+++ b/src/wpcli.php
@@ -65,21 +65,25 @@ class PHPCompat_Command extends WP_CLI_Command {
  *  Using this for now since there are issues with the PHPDoc syntax.
  *  TODO: Use PHPDoc syntax.
  */
-WP_CLI::add_command( 'phpcompat', 'PHPCompat_Command', array(
-	'shortdesc' => 'Test compatibility with different PHP versions.',
-	'synopsis'  => array(
-		array(
-			'type'     => 'positional',
-			'name'     => 'version',
-			'optional' => false,
-			'multiple' => false,
+WP_CLI::add_command(
+	'phpcompat',
+	'PHPCompat_Command',
+	array(
+		'shortdesc' => 'Test compatibility with different PHP versions.',
+		'synopsis'  => array(
+			array(
+				'type'     => 'positional',
+				'name'     => 'version',
+				'optional' => false,
+				'multiple' => false,
+			),
+			array(
+				'type'     => 'assoc',
+				'name'     => 'scan',
+				'optional' => true,
+				'default'  => 'active',
+				'options'  => array( 'active', 'all' ),
+			),
 		),
-		array(
-			'type'     => 'assoc',
-			'name'     => 'scan',
-			'optional' => true,
-			'default'  => 'active',
-			'options'  => array( 'active', 'all' ),
-		),
-	),
-));
+	)
+);

--- a/wpengine-phpcompat.php
+++ b/wpengine-phpcompat.php
@@ -117,7 +117,7 @@ class WPEngine_PHPCompat {
 		);
 
 		if ( version_compare( phpversion(), '5.3', '>=' ) ) {
-		    $versions = array( 'PHP 7.3' => '7.3') + $versions;
+            $versions = array( 'PHP 7.3' => '7.3' ) + $versions;
 		}
 
 		$old_versions = array( '5.6', '5.5', '5.4', '5.3' );
@@ -202,12 +202,14 @@ class WPEngine_PHPCompat {
 
 			$active_job = false;
 
-			$jobs = get_posts( array(
-				'posts_per_page' => -1,
-				'post_type'      => 'wpephpcompat_jobs',
-				'orderby'        => 'title',
-				'order'          => 'ASC',
-			) );
+			$jobs = get_posts(
+                array(
+                    'posts_per_page' => -1,
+                    'post_type'      => 'wpephpcompat_jobs',
+                    'orderby'        => 'title',
+                    'order'          => 'ASC',
+                )
+            );
 
 			if ( 0 < count( $jobs ) ) {
 				$active_job = $jobs[0]->post_title;
@@ -308,14 +310,17 @@ class WPEngine_PHPCompat {
 	 * @since 1.0.0
 	 */
 	public function create_job_queue() {
-		register_post_type( 'wpephpcompat_jobs', array(
-			'labels'      => array(
-				'name'          => __( 'Jobs', 'php-compatibility-checker' ),
-				'singular_name' => __( 'Job', 'php-compatibility-checker' ),
-			),
-			'public'      => false,
-			'has_archive' => false,
-		) );
+		register_post_type(
+            'wpephpcompat_jobs',
+            array(
+                'labels'      => array(
+                    'name'          => __( 'Jobs', 'php-compatibility-checker' ),
+                    'singular_name' => __( 'Job', 'php-compatibility-checker' ),
+                ),
+                'public'      => false,
+                'has_archive' => false,
+    		)
+        );
 	}
 
 	/**

--- a/wpengine-phpcompat.php
+++ b/wpengine-phpcompat.php
@@ -109,12 +109,16 @@ class WPEngine_PHPCompat {
 	 * @return array Associative array of available PHP versions.
 	 */
 	function get_phpversions() {
+
 		$versions = array(
-			'PHP 7.3' => '7.3',
 			'PHP 7.2' => '7.2',
 			'PHP 7.1' => '7.1',
 			'PHP 7.0' => '7.0',
 		);
+
+		if ( version_compare( phpversion(), '5.3', '>=' ) ) {
+		    $versions = array( 'PHP 7.3' => '7.3') + $versions;
+		}
 
 		$old_versions = array( '5.6', '5.5', '5.4', '5.3' );
 

--- a/wpengine-phpcompat.php
+++ b/wpengine-phpcompat.php
@@ -117,7 +117,7 @@ class WPEngine_PHPCompat {
 		);
 
 		if ( version_compare( phpversion(), '5.3', '>=' ) ) {
-            $versions = array( 'PHP 7.3' => '7.3' ) + $versions;
+			$versions = array( 'PHP 7.3' => '7.3' ) + $versions;
 		}
 
 		$old_versions = array( '5.6', '5.5', '5.4', '5.3' );
@@ -203,13 +203,13 @@ class WPEngine_PHPCompat {
 			$active_job = false;
 
 			$jobs = get_posts(
-                array(
-                    'posts_per_page' => -1,
-                    'post_type'      => 'wpephpcompat_jobs',
-                    'orderby'        => 'title',
-                    'order'          => 'ASC',
-                )
-            );
+				array(
+					'posts_per_page' => -1,
+					'post_type'      => 'wpephpcompat_jobs',
+					'orderby'        => 'title',
+					'order'          => 'ASC',
+				)
+			);
 
 			if ( 0 < count( $jobs ) ) {
 				$active_job = $jobs[0]->post_title;
@@ -311,16 +311,16 @@ class WPEngine_PHPCompat {
 	 */
 	public function create_job_queue() {
 		register_post_type(
-            'wpephpcompat_jobs',
-            array(
-                'labels'      => array(
-                    'name'          => __( 'Jobs', 'php-compatibility-checker' ),
-                    'singular_name' => __( 'Job', 'php-compatibility-checker' ),
-                ),
-                'public'      => false,
-                'has_archive' => false,
-    		)
-        );
+			'wpephpcompat_jobs',
+			array(
+				'labels'      => array(
+					'name'          => __( 'Jobs', 'php-compatibility-checker' ),
+					'singular_name' => __( 'Job', 'php-compatibility-checker' ),
+				),
+				'public'      => false,
+				'has_archive' => false,
+			)
+		);
 	}
 
 	/**

--- a/wpengine-phpcompat.php
+++ b/wpengine-phpcompat.php
@@ -110,6 +110,7 @@ class WPEngine_PHPCompat {
 	 */
 	function get_phpversions() {
 		$versions = array(
+			'PHP 7.3' => '7.3',
 			'PHP 7.2' => '7.2',
 			'PHP 7.1' => '7.1',
 			'PHP 7.0' => '7.0',


### PR DESCRIPTION
This pull request adds support for checking code for compatibility with PHP 7.3.  Note: The option to check against PHP 7.3 will only appear if the server is running on PHP 5.3 or greater.