### PR TITLE
Add PHP 7.4 Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ php:
   - 7.1
   - 7.2
   - 7.3
+  - 7.4
 env:
   - WP_VERSION=latest
   - WP_VERSION=4.5
@@ -30,12 +31,15 @@ matrix:
       env: WP_VERSION=5.2 WP_MULTISITE=1
     - php: 7.3
       env: WP_VERSION=latest WP_MULTISITE=1
-    - php: 7.3
+    - php: 7.4
+      env: WP_VERSION=5.2 WP_MULTISITE=1
+    - php: 7.4
+      env: WP_VERSION=latest WP_MULTISITE=1
+    - php: 7.4
       env: NPM_TESTS=1
   exclude:
     - php: 7.3
       env: WP_VERSION=4.5
-
 
 before_script:
   - |

--- a/composer.lock
+++ b/composer.lock
@@ -77,16 +77,16 @@
         },
         {
             "name": "phpcompatibility/php-compatibility",
-            "version": "9.2.0",
+            "version": "9.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
-                "reference": "3db1bf1e28123fd574a4ae2e9a84072826d51b5e"
+                "reference": "1f37659196e4f3113ea506a7efba201c52303bf1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/3db1bf1e28123fd574a4ae2e9a84072826d51b5e",
-                "reference": "3db1bf1e28123fd574a4ae2e9a84072826d51b5e",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/1f37659196e4f3113ea506a7efba201c52303bf1",
+                "reference": "1f37659196e4f3113ea506a7efba201c52303bf1",
                 "shasum": ""
             },
             "require": {
@@ -110,10 +110,6 @@
             ],
             "authors": [
                 {
-                    "name": "Contributors",
-                    "homepage": "https://github.com/PHPCompatibility/PHPCompatibility/graphs/contributors"
-                },
-                {
                     "name": "Wim Godden",
                     "homepage": "https://github.com/wimg",
                     "role": "lead"
@@ -122,6 +118,10 @@
                     "name": "Juliette Reinders Folmer",
                     "homepage": "https://github.com/jrfnl",
                     "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCompatibility/PHPCompatibility/graphs/contributors"
                 }
             ],
             "description": "A set of sniffs for PHP_CodeSniffer that checks for PHP cross-version compatibility.",
@@ -131,30 +131,32 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2019-06-27 19:58:56"
+            "time": "2019-11-15 04:12:02"
         },
         {
             "name": "phpcompatibility/phpcompatibility-paragonie",
-            "version": "1.0.1",
+            "version": "1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie.git",
-                "reference": "9160de79fcd683b5c99e9c4133728d91529753ea"
+                "reference": "b862bc32f7e860d0b164b199bd995e690b4b191c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/9160de79fcd683b5c99e9c4133728d91529753ea",
-                "reference": "9160de79fcd683b5c99e9c4133728d91529753ea",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/b862bc32f7e860d0b164b199bd995e690b4b191c",
+                "reference": "b862bc32f7e860d0b164b199bd995e690b4b191c",
                 "shasum": ""
             },
             "require": {
                 "phpcompatibility/php-compatibility": "^9.0"
             },
             "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4"
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5",
+                "paragonie/random_compat": "dev-master",
+                "paragonie/sodium_compat": "dev-master"
             },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
                 "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
             },
             "type": "phpcodesniffer-standard",
@@ -181,20 +183,20 @@
                 "polyfill",
                 "standards"
             ],
-            "time": "2018-12-16 19:10:44"
+            "time": "2019-11-04 15:17:54"
         },
         {
             "name": "phpcompatibility/phpcompatibility-wp",
-            "version": "2.0.0",
+            "version": "2.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibilityWP.git",
-                "reference": "cb303f0067cd5b366a41d4fb0e254fb40ff02efd"
+                "reference": "41bef18ba688af638b7310666db28e1ea9158b2f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/cb303f0067cd5b366a41d4fb0e254fb40ff02efd",
-                "reference": "cb303f0067cd5b366a41d4fb0e254fb40ff02efd",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/41bef18ba688af638b7310666db28e1ea9158b2f",
+                "reference": "41bef18ba688af638b7310666db28e1ea9158b2f",
                 "shasum": ""
             },
             "require": {
@@ -202,10 +204,10 @@
                 "phpcompatibility/phpcompatibility-paragonie": "^1.0"
             },
             "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3"
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5"
             },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
                 "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
             },
             "type": "phpcodesniffer-standard",
@@ -231,7 +233,7 @@
                 "standards",
                 "wordpress"
             ],
-            "time": "2018-10-07 18:31:37"
+            "time": "2019-08-28 14:22:28"
         },
         {
             "name": "squizlabs/php_codesniffer",

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,5 @@
 # PHP Compatibility Checker <a href="https://travis-ci.org/wpengine/phpcompat"><img src="https://travis-ci.org/wpengine/phpcompat.svg?branch=master"></a>
-**Contributors:** [wpengine](https://profiles.wordpress.org/wpengine), [octalmage](https://profiles.wordpress.org/octalmage), [stevenkword](https://profiles.wordpress.org/stevenkword), [Taylor4484](https://profiles.wordpress.org/Taylor4484), [pross](https://profiles.wordpress.org/pross), [jcross](https://profiles.wordpress.org/jcross)
+**Contributors:** [wpengine](https://profiles.wordpress.org/wpengine), [octalmage](https://profiles.wordpress.org/octalmage), [stevenkword](https://profiles.wordpress.org/stevenkword), [Taylor4484](https://profiles.wordpress.org/Taylor4484), [pross](https://profiles.wordpress.org/pross), [jcross](https://profiles.wordpress.org/jcross), [shooper](https://profiles.wordpress.org/shooper)
 **Tags:** php 7, php 5.5, php, version, compatibility, checker, wp engine, wpe, wpengine
 **Requires at least:** 3.5
 **Tested up to:** 5.3.0

--- a/readme.md
+++ b/readme.md
@@ -21,11 +21,11 @@ This plugin will lint theme and plugin code inside your WordPress file system an
 
 **This plugin relies on WP-Cron to scan files in the background. The scan will get stuck if the site's WP-Cron isn't running correctly. Please see the [FAQ](https://wordpress.org/plugins/php-compatibility-checker/faq/) for more information.**
 
-### Update to PHP 7.3 ###
-* Use this plugin to check your site for compatibility up to PHP 7.3!
-* As of [July 2019](https://wordpress.org/about/stats/), 20.1% of WordPress websites run a PHP version older than PHP 5.6.
+### Update to PHP 7.4 ###
+* Use this plugin to check your site for compatibility up to PHP 7.4!
+* As of [November 2019](https://wordpress.org/about/stats/), 12.9% of WordPress websites run a PHP version older than PHP 5.6.
 * These versions of PHP have been [deprecated and unsupported](https://secure.php.net/supported-versions.php) for over 2 years.
-* Only 54.1% of WordPress websites run PHP 7, the current main version of PHP.
+* Only 63.1% of WordPress websites run PHP 7, the current main version of PHP.
 
 
 ### Disclaimer ###
@@ -64,7 +64,7 @@ PHP Compatibility Checker includes WP-CLI command support:
 	    - active
 	    - all
 
-Example: `wp phpcompat 7.2 --scan=active`
+Example: `wp phpcompat 7.4 --scan=active`
 
 
 ## Frequently Asked Questions ##
@@ -117,6 +117,9 @@ To disclose security issues for this plugin please email WordPress@wpengine.com
 
 
 ## Changelog ##
+### 1.6.0 ###
+- Added support for PHP 7.4 compatibility checks
+
 ### 1.5.0 ###
 - Added support for PHP 7.3 compatibility checks
 

--- a/readme.md
+++ b/readme.md
@@ -2,8 +2,8 @@
 **Contributors:** [wpengine](https://profiles.wordpress.org/wpengine), [octalmage](https://profiles.wordpress.org/octalmage), [stevenkword](https://profiles.wordpress.org/stevenkword), [Taylor4484](https://profiles.wordpress.org/Taylor4484), [pross](https://profiles.wordpress.org/pross), [jcross](https://profiles.wordpress.org/jcross)
 **Tags:** php 7, php 5.5, php, version, compatibility, checker, wp engine, wpe, wpengine
 **Requires at least:** 3.5
-**Tested up to:** 5.2.2
-**Stable tag:** 1.5.0
+**Tested up to:** 5.3.0
+**Stable tag:** 1.6.0
 **License:** GPLv2 or later
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === PHP Compatibility Checker ===
-Contributors: wpengine, octalmage, stevenkword, Taylor4484, pross, jcross
+Contributors: wpengine, octalmage, stevenkword, Taylor4484, pross, jcross, shooper
 Tags: php 7, php 5.5, php, version, compatibility, checker, wp engine, wpe, wpengine
 Requires at least: 3.5
 Tested up to: 5.3.0

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: wpengine, octalmage, stevenkword, Taylor4484, pross, jcross
 Tags: php 7, php 5.5, php, version, compatibility, checker, wp engine, wpe, wpengine
 Requires at least: 3.5
-Tested up to: 5.2.2
-Stable tag: 1.5.0
+Tested up to: 5.3.0
+Stable tag: 1.6.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -21,11 +21,11 @@ This plugin will lint theme and plugin code inside your WordPress file system an
 
 **This plugin relies on WP-Cron to scan files in the background. The scan will get stuck if the site's WP-Cron isn't running correctly. Please see the [FAQ](https://wordpress.org/plugins/php-compatibility-checker/faq/) for more information.**
 
-= Update to PHP 7.3 =
-* Use this plugin to check your site for compatibility up to PHP 7.3!
-* As of [July 2019](https://wordpress.org/about/stats/), 20.1% of WordPress websites run a PHP version older than PHP 5.6.
+= Update to PHP 7.4 =
+* Use this plugin to check your site for compatibility up to PHP 7.4!
+* As of [November 2019](https://wordpress.org/about/stats/), 12.9% of WordPress websites run a PHP version older than PHP 5.6.
 * These versions of PHP have been [deprecated and unsupported](https://secure.php.net/supported-versions.php) for over 2 years.
-* Only 54.1% of WordPress websites run PHP 7, the current main version of PHP.
+* Only 63.1% of WordPress websites run PHP 7, the current main version of PHP.
 
 
 = Disclaimer =
@@ -64,7 +64,7 @@ PHP Compatibility Checker includes WP-CLI command support:
     - active
     - all
 `
-Example: `wp phpcompat 7.2 --scan=active`
+Example: `wp phpcompat 7.4 --scan=active`
 
 
 == Frequently Asked Questions ==
@@ -113,6 +113,9 @@ To disclose security issues for this plugin please email WordPress@wpengine.com
 2. Compatibility results screen
 
 == Changelog ==
+= 1.6.0 =
+- Added support for PHP 7.4 compatibility checks
+
 = 1.5.0 =
 - Added support for PHP 7.3 compatibility checks
 

--- a/wpengine-phpcompat.php
+++ b/wpengine-phpcompat.php
@@ -10,7 +10,7 @@
  * Plugin URI:  https://wpengine.com
  * Description: Make sure your plugins and themes are compatible with newer PHP versions.
  * Author:      WP Engine
- * Version:     1.5.0
+ * Version:     1.6.0
  * Author URI:  https://wpengine.com
  * Text Domain: php-compatibility-checker
  */

--- a/wpengine-phpcompat.php
+++ b/wpengine-phpcompat.php
@@ -118,6 +118,7 @@ class WPEngine_PHPCompat {
 
 		if ( version_compare( phpversion(), '5.3', '>=' ) ) {
 			$versions = array( 'PHP 7.3' => '7.3' ) + $versions;
+			$versions = array( 'PHP 7.4' => '7.4' ) + $versions;
 		}
 
 		$old_versions = array( '5.6', '5.5', '5.4', '5.3' );


### PR DESCRIPTION
This patch adds support for PHP 7.4 compatibility checking.  To test it, add this function to your theme/plugin:

```
	function ternary_deprecation() {

		return 1 ? 2 : 3 ? 4 : 5; // deprecated in 7.4

	}

```

and run the plugin. 