### PR TITLE
Add a user editable list of plugin names to skip

### DIFF
--- a/src/js/run.js
+++ b/src/js/run.js
@@ -1,5 +1,5 @@
 // Global variables.
-var test_version, only_active, timer;
+var test_version, only_active, skip_list, timer;
 
 jQuery( document ).ready(function($) {
 
@@ -35,10 +35,12 @@ jQuery( document ).ready(function($) {
 		resetDisplay();
 		test_version = $( 'input[name=phptest_version]:checked' ).val();
 		only_active = $( 'input[name=active_plugins]:checked' ).val();
+		skip_list = $( 'input[name=skip_list]' ).val();
 		var data = {
 			'action': 'wpephpcompat_start_test',
 			'test_version': test_version,
 			'only_active': only_active,
+			'skip_list': skip_list,
 			'startScan': 1
 		};
 		$( '.wpe-pcc-test-version' ).text(test_version);

--- a/src/wpephpcompat.php
+++ b/src/wpephpcompat.php
@@ -53,6 +53,15 @@ class WPEPHPCompat {
 	 */
 	public $only_active = null;
 
+    /**
+     * Skip some plugins by name, separated by `;`
+     *
+     * @since 1.5.0
+     * @var string
+     */
+    public $skip_list = null;
+
+
 	/**
 	 * The base directory for the plugin.
 	 *
@@ -166,6 +175,7 @@ class WPEPHPCompat {
 			update_option( 'wpephpcompat.status', '1', false );
 			update_option( 'wpephpcompat.test_version', $this->test_version, false );
 			update_option( 'wpephpcompat.only_active', $this->only_active, false );
+            update_option( 'wpephpcompat.skip_list', $this->skip_list, false );
 
 			$this->debug_log( 'Generating directory list.' );
 
@@ -345,7 +355,10 @@ class WPEPHPCompat {
 
 		$update_plugins = get_site_transient( 'update_plugins' );
 
+        $ignored_plugins = $this->skip_list ? explode(';', $this->skip_list) : [];
+
 		foreach ( $all_plugins as $k => $v ) {
+
 			// Exclude our plugin.
 			if ( 'PHP Compatibility Checker' === $v['Name'] ) {
 				continue;
@@ -360,6 +373,9 @@ class WPEPHPCompat {
 					continue;
 				}
 			}
+            if (in_array( $v['Name'], $ignored_plugins, true ) ) {
+                continue;
+            }
 
 			$plugin_file = plugin_dir_path( $k );
 

--- a/wpengine-phpcompat.php
+++ b/wpengine-phpcompat.php
@@ -155,7 +155,7 @@ class WPEngine_PHPCompat {
 			$wpephpc = new WPEPHPCompat( dirname( __FILE__ ) );
 
 			$test_data = array();
-			foreach ( array( 'test_version', 'only_active' ) as $key ) {
+			foreach ( array( 'test_version', 'only_active', 'skip_list' ) as $key ) {
 				if ( isset( $_POST[ $key ] ) ) {
 					$test_data[ $key ] = sanitize_text_field( $_POST[ $key ] );
 				}
@@ -167,7 +167,7 @@ class WPEngine_PHPCompat {
 				$wpephpc->clean_after_scan();
 
 				// Fork so we can close the connection.
-				$this->fork_scan( $test_data['test_version'], $test_data['only_active'] );
+				$this->fork_scan( $test_data['test_version'], $test_data['only_active'], $test_data['skip_list'] );
 			} else {
 				if ( isset( $test_data['test_version'] ) ) {
 					$wpephpc->test_version = $test_data['test_version'];
@@ -176,6 +176,10 @@ class WPEngine_PHPCompat {
 				if ( isset( $test_data['only_active'] ) ) {
 					$wpephpc->only_active = $test_data['only_active'];
 				}
+
+                if ( isset( $test_data['skip_list'] ) ) {
+                    $wpephpc->skip_list = $test_data['skip_list'];
+                }
 
 				$wpephpc->start_test();
 			}
@@ -199,6 +203,7 @@ class WPEngine_PHPCompat {
 			$total_jobs   = get_option( 'wpephpcompat.numdirs' );
 			$test_version = get_option( 'wpephpcompat.test_version' );
 			$only_active  = get_option( 'wpephpcompat.only_active' );
+            $skip_list    = get_option( 'wpephpcompat.skip_list' );
 
 			$active_job = false;
 
@@ -249,7 +254,7 @@ class WPEngine_PHPCompat {
 	 * @param string $test_version Version of PHP to test.
 	 * @param string $only_active  Whether to scan only active plugins or all.
 	 */
-	public function fork_scan( $test_version, $only_active ) {
+	public function fork_scan( $test_version, $only_active, $skip_list ) {
 		$query = array(
 			'action' => 'wpephpcompat_start_test',
 		);
@@ -258,6 +263,7 @@ class WPEngine_PHPCompat {
 		$body = array(
 			'test_version' => $test_version,
 			'only_active'  => $only_active,
+            'skip_list'    => $skip_list
 		);
 
 		// Instantly return!
@@ -404,6 +410,7 @@ class WPEngine_PHPCompat {
 		// Discover last options used.
 		$test_version = get_option( 'wpephpcompat.test_version' );
 		$only_active  = get_option( 'wpephpcompat.only_active' );
+        $skip_list    = get_option( 'wpephpcompat.skip_list' );
 
 		// Determine if current site is a WP Engine customer.
 		$is_wpe_customer = ! empty( $_SERVER['IS_WPE'] ) && $_SERVER['IS_WPE'];
@@ -413,6 +420,7 @@ class WPEngine_PHPCompat {
 		// Assigns defaults for the scan if none are found in the database.
 		$test_version = ( ! empty( $test_version ) ) ? $test_version : '7.0';
 		$only_active  = ( ! empty( $only_active ) ) ? $only_active : 'yes';
+        $skip_list  = ( ! empty( $skip_list ) ) ? $skip_list : 'FFATG Cookie Notice';
 
 		// Content variables.
 		$url_get_hosting          = esc_url( 'https://wpeng.in/5a0336/' );
@@ -455,6 +463,14 @@ class WPEngine_PHPCompat {
 									</fieldset>
 								</td>
 							</tr>
+                            <tr>
+                                <th scope="row"><label for="skip_list"><?php _e( 'Skip List', 'php-compatibility-checker' ); ?></label></th>
+                                <td>
+                                    <fieldset>
+                                        <label><?php _e( 'Optional list of Plugin Names separated by <code>;</code> that won\'t be checked', 'php-compatibility-checker' ); ?><br><br><input type="text" name="skip_list" style="width: 100%;" value="<?php echo $skip_list; ?>" /></label>
+                                    </fieldset>
+                                </td>
+                            </tr>
 							<tr>
 								<th scope="row"></th>
 									<td>


### PR DESCRIPTION
Adds an input field:

![Screen Shot 2020-02-04 at 3 07 40 PM](https://user-images.githubusercontent.com/12877287/73795703-1ef49780-4760-11ea-8aaa-cd882e5d5fc8.png)

When Plugin Name(s) is(/are) entered (separated by `;`) then those plugins get skipped.