### PR TITLE
[PI-3451] Replace grunt-phpcs with phpcs composer command.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ matrix:
       env: WP_VERSION=5.2 WP_MULTISITE=1
     - php: 7.3
       env:
-        - WP_VERSION=latest WP_MULTISITE=1
+        env: WP_VERSION=latest WP_MULTISITE=1 PHPCS=1
         - PHPCS=1
     - php: 7.3
       env: NPM_TESTS=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,11 +29,11 @@ matrix:
     - php: 7.3
       env: WP_VERSION=5.2 WP_MULTISITE=1
     - php: 7.3
-      env: WP_VERSION=latest WP_MULTISITE=1
+      env:
+        - WP_VERSION=latest WP_MULTISITE=1
+        - PHPCS=1
     - php: 7.3
       env: NPM_TESTS=1
-    - php: 7.3
-      env: PHPCS=1
   exclude:
     - php: 7.3
       env: WP_VERSION=4.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ matrix:
       env: WP_VERSION=latest WP_MULTISITE=1
     - php: 7.3
       env: NPM_TESTS=1
+      env: PHPCS=1
   exclude:
     - php: 7.3
       env: WP_VERSION=4.5
@@ -87,12 +88,12 @@ before_script:
     fi
 script:
   - |
+    if [[ "$PHPCS" == "1" ]]; then
+      composer phpcs
+    fi
+
     if [[ "$NPM_TESTS" == "1" ]]; then
       npm test
     else
-      if [[ "$TRAVIS_PHP_VERSION" != "5.2" ]]; then
-        composer phpcs
-      fi
-
       phpunit
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -90,5 +90,6 @@ script:
     if [[ "$NPM_TESTS" == "1" ]]; then
       npm test
     else
+      composer phpcs
       phpunit
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -90,6 +90,11 @@ script:
     if [[ "$NPM_TESTS" == "1" ]]; then
       npm test
     else
-      composer phpcs
+      if [[ "$TRAVIS_PHP_VERSION" == "5.2" ]]; then
+        /home/travis/.phpenv/versions/5.4/bin/composer phpcs
+      else
+        composer phpcs
+      fi
+
       phpunit
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ matrix:
       env: WP_VERSION=latest WP_MULTISITE=1
     - php: 7.3
       env: NPM_TESTS=1
+    - php: 7.3
       env: PHPCS=1
   exclude:
     - php: 7.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -90,9 +90,7 @@ script:
     if [[ "$NPM_TESTS" == "1" ]]; then
       npm test
     else
-      if [[ "$TRAVIS_PHP_VERSION" == "5.2" ]]; then
-        /home/travis/.phpenv/versions/5.4/bin/composer phpcs
-      else
+      if [[ "$TRAVIS_PHP_VERSION" != "5.2" ]]; then
         composer phpcs
       fi
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -20,23 +20,13 @@ module.exports = function(grunt) {
 		},
 		phplint: {
 			plugin: phpPaths
-		},
-		phpcs: {
-			plugin: {
-				src: phpPaths
-			},
-			options: {
-				bin: 'vendor/bin/phpcs',
-				standard: 'src/ruleset-wordpress.xml'
-			}
 		}
 	});
 
 	grunt.loadNpmTasks('grunt-wp-readme-to-markdown');
 	grunt.loadNpmTasks('grunt-phplint');
-	grunt.loadNpmTasks('grunt-phpcs');
 
-	grunt.registerTask('default', ['phplint', 'phpcs']);
+	grunt.registerTask('default', ['phplint']);
 
 	grunt.registerTask('readme', ['wp_readme_to_markdown']);
 };

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,8 @@
 		],
 		"post-install-cmd": [
 			"cd php52; composer install; cd .."
-		]
+		],
+		"phpcs": "phpcs --standard=src/ruleset-wordpress.xml wpengine-phpcompat.php load-files.php src/*.php",
+		"phpcs:fix": "phpcbf --standard=src/ruleset-wordpress.xml wpengine-phpcompat.php load-files.php src/*.php"
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -653,12 +653,6 @@
         }
       }
     },
-    "grunt-phpcs": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/grunt-phpcs/-/grunt-phpcs-0.4.0.tgz",
-      "integrity": "sha1-oI1iX8ZEZeRTsr2T+BCyqB6Uvao=",
-      "dev": true
-    },
     "grunt-phplint": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/grunt-phplint/-/grunt-phplint-0.0.8.tgz",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "devDependencies": {
     "grunt": "^0.4.5",
     "grunt-cli": "^1.2.0",
-    "grunt-phpcs": "^0.4.0",
     "grunt-phplint": "0.0.8",
     "grunt-wp-readme-to-markdown": "^2.0.0",
     "lodash": "4.17.13",


### PR DESCRIPTION
This pull request replaces the outdated [grunt-phpcs](https://www.npmjs.com/package/grunt-phpcs) with a composer phpcs command.

The grunt-phpcs package has not been updated in over 5 years and was setting off github security alarms due to outdated dependencies.

The new composer command `composer phpcs` wraps `vendor/bin/phpcs --standard=src/ruleset-wordpress.xml wpengine-phpcompat.php load-files.php src/*.php` command. This will analyze the same files with the same ruleset as a phpcs grunt script.

In addition, a `composer phpcs:fix` command was also added for fixable code sniffer errors. It wraps the `vendor/bin/phpcbf --standard=src/ruleset-wordpress.xml wpengine-phpcompat.php load-files.php src/*.php` command.

**Note: The `composer phpcs` command will not be ran in Travis for php 5.2. This is due to composer not supporting php 5.2. Travis will soon be removing older builds of php in the near future.** 

### Testing

Run `composer phpcs` to run the command. Also run `npm run test` to see passing javascript tests.