### PR TITLE
NPM Security Updates

### DIFF
--- a/.phplint.yml
+++ b/.phplint.yml
@@ -1,0 +1,7 @@
+path: ./
+jobs: 10
+cache: build/phplint.cache
+extensions:
+  - php
+exclude:
+  - vendor

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,9 @@ matrix:
     - php: 7.3
       env: WP_VERSION=5.2 WP_MULTISITE=1
     - php: 7.3
-      env: WP_VERSION=latest WP_MULTISITE=1
+      env:
+        env: WP_VERSION=latest WP_MULTISITE=1 PHPCS=1
+        - PHPCS=1
     - php: 7.3
       env: NPM_TESTS=1
   exclude:
@@ -87,6 +89,10 @@ before_script:
     fi
 script:
   - |
+    if [[ "$PHPCS" == "1" ]]; then
+      composer phpcs
+    fi
+
     if [[ "$NPM_TESTS" == "1" ]]; then
       npm test
     else

--- a/.travis.yml
+++ b/.travis.yml
@@ -89,11 +89,11 @@ script:
   - |
     if [[ "$PHPCS" == "1" ]]; then
       composer phpcs
-      bash php-lint.sh
     fi
 
     if [[ "$NPM_TESTS" == "1" ]]; then
       npm test
     else
+      bash php-lint.sh
       phpunit
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,9 +29,7 @@ matrix:
     - php: 7.3
       env: WP_VERSION=5.2 WP_MULTISITE=1
     - php: 7.3
-      env:
-        env: WP_VERSION=latest WP_MULTISITE=1 PHPCS=1
-        - PHPCS=1
+      env: WP_VERSION=latest WP_MULTISITE=1 PHPCS=1
     - php: 7.3
       env: NPM_TESTS=1
   exclude:
@@ -91,6 +89,7 @@ script:
   - |
     if [[ "$PHPCS" == "1" ]]; then
       composer phpcs
+      bash php-lint.sh
     fi
 
     if [[ "$NPM_TESTS" == "1" ]]; then

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -20,23 +20,13 @@ module.exports = function(grunt) {
 		},
 		phplint: {
 			plugin: phpPaths
-		},
-		phpcs: {
-			plugin: {
-				src: phpPaths
-			},
-			options: {
-				bin: 'vendor/bin/phpcs',
-				standard: 'src/ruleset-wordpress.xml'
-			}
 		}
 	});
 
 	grunt.loadNpmTasks('grunt-wp-readme-to-markdown');
 	grunt.loadNpmTasks('grunt-phplint');
-	grunt.loadNpmTasks('grunt-phpcs');
 
-	grunt.registerTask('default', ['phplint', 'phpcs']);
+	grunt.registerTask('default', ['phplint']);
 
 	grunt.registerTask('readme', ['wp_readme_to_markdown']);
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,11 +1,4 @@
-var phpPaths = [
-	'wpengine-phpcompat.php',
-	'load-files.php',
-	'src/*.php',
-];
-
 module.exports = function(grunt) {
-
 	grunt.initConfig({
 		wp_readme_to_markdown: {
 			options: {
@@ -17,17 +10,12 @@ module.exports = function(grunt) {
 					'readme.md': 'readme.txt'
 				},
 			},
-		},
-		phplint: {
-			plugin: phpPaths
 		}
 	});
 
 	grunt.loadNpmTasks('grunt-wp-readme-to-markdown');
-	grunt.loadNpmTasks('grunt-phplint');
 
-	grunt.registerTask('default', ['phplint']);
-
+	grunt.registerTask('default', []);
 	grunt.registerTask('readme', ['wp_readme_to_markdown']);
 };
 

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,8 @@
 		],
 		"post-install-cmd": [
 			"cd php52; composer install; cd .."
-		]
+		],
+		"phpcs": "phpcs --standard=src/ruleset-wordpress.xml wpengine-phpcompat.php load-files.php src/*.php",
+		"phpcs:fix": "phpcbf --standard=src/ruleset-wordpress.xml wpengine-phpcompat.php load-files.php src/*.php"
 	}
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,9 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "hash": "6f3f111cee87df2a6b762e6eeade451e",
     "content-hash": "444578a8dfe80cf6550e1434f655d2e6",
     "packages": [
         {
@@ -73,7 +72,7 @@
                 "stylecheck",
                 "tests"
             ],
-            "time": "2017-12-06 16:27:17"
+            "time": "2017-12-06T16:27:17+00:00"
         },
         {
             "name": "phpcompatibility/php-compatibility",
@@ -131,7 +130,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2019-06-27 19:58:56"
+            "time": "2019-06-27T19:58:56+00:00"
         },
         {
             "name": "phpcompatibility/phpcompatibility-paragonie",
@@ -181,7 +180,7 @@
                 "polyfill",
                 "standards"
             ],
-            "time": "2018-12-16 19:10:44"
+            "time": "2018-12-16T19:10:44+00:00"
         },
         {
             "name": "phpcompatibility/phpcompatibility-wp",
@@ -231,7 +230,7 @@
                 "standards",
                 "wordpress"
             ],
-            "time": "2018-10-07 18:31:37"
+            "time": "2018-10-07T18:31:37+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -309,7 +308,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2018-11-07 22:31:41"
+            "time": "2018-11-07T22:31:41+00:00"
         }
     ],
     "packages-dev": [
@@ -354,7 +353,7 @@
                 "standards",
                 "wordpress"
             ],
-            "time": "2018-12-18 09:43:51"
+            "time": "2018-12-18T09:43:51+00:00"
         }
     ],
     "aliases": [],

--- a/package-lock.json
+++ b/package-lock.json
@@ -653,12 +653,6 @@
         }
       }
     },
-    "grunt-phpcs": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/grunt-phpcs/-/grunt-phpcs-0.4.0.tgz",
-      "integrity": "sha1-oI1iX8ZEZeRTsr2T+BCyqB6Uvao=",
-      "dev": true
-    },
     "grunt-phplint": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/grunt-phplint/-/grunt-phplint-0.0.8.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -116,40 +116,6 @@
       "integrity": "sha512-c5mRlguI/Pe2dSZmpER62rSCu0ryKmWddzRYsuXc50U2/g8jMOulc31VZMa4mYx31U5xsmSOpDCgH88Vl9cDGQ==",
       "dev": true
     },
-    "cache-swap": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/cache-swap/-/cache-swap-0.0.6.tgz",
-      "integrity": "sha1-F834NebDAf0VgJCwPRzDb0Z7FpU=",
-      "dev": true,
-      "requires": {
-        "async": "~0.2.6",
-        "lodash": "~1.1.0",
-        "rimraf": "~2.1.4"
-      },
-      "dependencies": {
-        "async": {
-          "version": "0.2.10",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
-          "dev": true
-        },
-        "lodash": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.1.1.tgz",
-          "integrity": "sha1-QaKy6aAOZNbRmZ8UP/awdV9ruyQ=",
-          "dev": true
-        },
-        "rimraf": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.1.4.tgz",
-          "integrity": "sha1-Wm62Lu2gaPUe3lDymz5c0i89m7I=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "~1"
-          }
-        }
-      }
-    },
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
@@ -651,16 +617,6 @@
           "integrity": "sha1-jzSZxSRdNG1oLlsNO0B2fgnxqSw=",
           "dev": true
         }
-      }
-    },
-    "grunt-phplint": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/grunt-phplint/-/grunt-phplint-0.0.8.tgz",
-      "integrity": "sha1-wSeqKP930jnBSgHwUMx7cVnOkMA=",
-      "dev": true,
-      "requires": {
-        "cache-swap": "~0.0.2",
-        "grunt": "~0.4.1"
       }
     },
     "grunt-wp-readme-to-markdown": {

--- a/package.json
+++ b/package.json
@@ -3,16 +3,14 @@
   "devDependencies": {
     "grunt": "^0.4.5",
     "grunt-cli": "^1.2.0",
-    "grunt-phplint": "0.0.8",
     "grunt-wp-readme-to-markdown": "^2.0.0",
     "lodash": "4.17.13",
     "minimatch": "3.0.2",
     "node-qunit-phantomjs": "^1.4.0"
   },
   "scripts": {
-    "test": "npm run test:lint && npm run test:qunit",
+    "test": "npm run test:qunit",
     "test:qunit": "node-qunit-phantomjs tests/qunit/index.html  --verbose",
-    "test:lint": "grunt",
     "readme": "grunt readme"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "devDependencies": {
     "grunt": "^0.4.5",
     "grunt-cli": "^1.2.0",
-    "grunt-phpcs": "^0.4.0",
     "grunt-phplint": "0.0.8",
     "grunt-wp-readme-to-markdown": "^2.0.0",
     "lodash": "4.17.13",

--- a/php-lint.sh
+++ b/php-lint.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+find . -not \( -path ./vendor -prune \) -not \( -path ./php52 -prune \) -type f -name '*.php' -print0 | xargs -0 -n1 -P4 -I {} php -l -n {} | (! grep -v "No syntax errors detected" )


### PR DESCRIPTION
This pull request removes two npm packages which have security warnings; [grunt-phpcs](https://www.npmjs.com/package/grunt-phpcs) and [grunt-phplint](https://www.npmjs.com/package/grunt-phplint). Both of these npm packages have not been updated in 3+ years.

`grunt-phpcs` was replaced by a composer command `composer phpcs`. This can be cleaned up in the future if needed.

`grunt-phplint` was replaced by a bash script [php-lint.sh](https://github.com/wpengine/phpcompat/blob/ryanmeier/feature/npm-security-updates/php-lint.sh). A bash script was used due to current available composer packages requiring php 7.2 and greater or have been abandoned. This made the current Travis build messy. In the future a composer package could be used as the php requirements change.

Also, thank you to @jrfnl for their valuable input during this change.