### PR TITLE
Updated Travis to run php lint on all php versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,11 +89,11 @@ script:
   - |
     if [[ "$PHPCS" == "1" ]]; then
       composer phpcs
-      bash php-lint.sh
     fi
 
     if [[ "$NPM_TESTS" == "1" ]]; then
       npm test
     else
+      bash php-lint.sh
       phpunit
     fi


### PR DESCRIPTION
This pull request moves the `bash php-lint.sh` command in the Travis config to run lint on all versions of php.