### PR TITLE
[PI-3518] Add deploy_job To CircleCI Workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,6 +72,10 @@ references:
       - run:
           name: Run WordPress PHPUnit Tests
           command: composer test
+  workflow_job: &workflow_job
+    filters:
+      tags:
+        only: /.*/
 
 jobs:
   job_test_javascript:
@@ -158,23 +162,45 @@ workflows:
           requires:
             - job_test_javascript
       - job_test_php56_min:
+          <<: *workflow_job
           requires:
             - job_php_code_standards
       - job_test_php56:
+          <<: *workflow_job
           requires:
             - job_php_code_standards
       - job_test_php70:
+          <<: *workflow_job
           requires:
             - job_php_code_standards
       - job_test_php71:
+          <<: *workflow_job
           requires:
             - job_php_code_standards
       - job_test_php72:
+          <<: *workflow_job
           requires:
             - job_php_code_standards
       - job_test_php73_min:
+          <<: *workflow_job
           requires:
             - job_php_code_standards
       - job_test_php73:
+          <<: *workflow_job
           requires:
             - job_php_code_standards
+      - deploy_job:
+          requires:
+            - job_test_php56_min
+            - job_test_php56
+            - job_test_php56_min
+            - job_test_php70
+            - job_test_php71
+            - job_test_php72
+            - job_test_php73_min
+            - job_test_php73
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^(\d+)\.(\d+)(\.\d+)?$/


### PR DESCRIPTION
This pull request adds the `deploy_job` to the workflow in the `.circleci/config.yml` file. The `deploy_job` will be triggered when a release from Github is created. In order for the `deploy_job` to start, all other checks and tests jobs will need to pass successfully.

Documentation on releasing a new version the plugin will be added to the wiki shortly.

### Internal Ticket
[PI-3518](https://wpengine.atlassian.net/browse/PI-3518)