### PR TITLE
Adds whitelist entry for WP Engine SPM

### DIFF
--- a/src/wpephpcompat.php
+++ b/src/wpephpcompat.php
@@ -69,6 +69,7 @@ class WPEPHPCompat {
 	 *  @var array
 	 */
 	public $whitelist = array(
+		'*/autoupdater/*'                                 => '7.0', // WP Engine Smart Plugin Manager uses a php5 package to maintain backwards compatibility.
 		'*/jetpack/*'                                     => '7.0', // https://github.com/wpengine/phpcompat/wiki/Results#jetpack
 		'*/wordfence/*'                                   => '7.0', // https://github.com/wpengine/phpcompat/wiki/Results#wordfence-security
 		'*/woocommerce/*'                                 => '7.0', // https://github.com/wpengine/phpcompat/wiki/Results#woocommerce


### PR DESCRIPTION
SPM is getting false positive failures using the PHP Compatibility Checker. 

From Peter Mocko 

> This is the exact directory that we keep for backward compatibility with PHP5: 
wp-content/plugins/autoupdater/lib/vendor
> There are two packages that we use, that are also a part of WP core since some not old enough WP version - at least from SPM perspective
> paragonie/sodium_compat
> paragonie/random_compat
> 

From my understanding, we maintain a whitelist with a verified version that the plugin is compatible with. This PR mirrors that pattern using the SPM directory slug. Should be working with this. :) 