### PR TITLE
Add/GitHub actions

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -1,23 +1,27 @@
-+ php52/vendor/bin
-+ vendor/bin
+# Directories
+/.circleci
+/.git
+/.github
+/assets
 - bin
-.circleci
+/helpers
++ php52/vendor/bin
+/tests
++ vendor/bin
+
+# Files
 .distignore
-.git
 .gitignore
 .phplint.yml
-Dockerfile
-Gruntfile.js
-Makefile
 build.sh
 composer.json
 composer.lock
 docker-compose.yml
-helpers
+Dockerfile
+Gruntfile.js
+Makefile
 package-lock.json
 package.json
 php-lint.sh
 phpunit.xml.dist
 readme.md
-tests
-assets

--- a/.github/workflows/dotorg-asset-readme-update.yml
+++ b/.github/workflows/dotorg-asset-readme-update.yml
@@ -1,0 +1,19 @@
+name: Plugin asset/readme update
+
+on:
+  push:
+    branches:
+    - master
+
+jobs:
+  trunk:
+    name: Push to master
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: WordPress.org plugin asset/readme update
+      uses: 10up/action-wordpress-plugin-asset-update@stable
+      env:
+        SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+        SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+        SLUG: php-compatibility-checker

--- a/.github/workflows/dotorg-push-deploy.yml
+++ b/.github/workflows/dotorg-push-deploy.yml
@@ -1,0 +1,41 @@
+name: Deploy to WordPress.org
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  tag:
+    name: New release
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Set Node.js 12
+      uses: actions/setup-node@v1
+      with:
+        node-version: '12.x'
+    - name: composer install
+      run: composer install --no-dev
+    - name: Build
+      run: |
+        npm install
+        npm run build
+    - name: WordPress Plugin Deploy
+      id: deploy
+      uses: 10up/action-wordpress-plugin-deploy@stable
+      with:
+        generate-zip: true
+      env:
+        SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+        SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+        SLUG: php-compatibility-checker
+    - name: Upload release asset
+      uses: actions/upload-release-asset@main
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ${{github.workspace}}/php-compatibility-checker.zip
+        asset_name: php-compatibility-checker.zip
+        asset_content_type: application/zip

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,31 @@
+name: Linting
+
+on:
+  push:
+    branches:
+      - develop
+      - master
+  pull_request:
+    branches:
+      - develop
+      - master #can remove this if/when `develop` set as default branch
+
+jobs:
+  phpcs:
+    name: PHPCS
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Set PHP version
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: '7.2'
+        coverage: none
+        tools: composer:v1
+    - name: composer install
+      run: composer install
+    - name: PHPCS check
+      uses: chekalsky/phpcs-action@v1
+      with:
+        phpcs_bin_path: './vendor/bin/phpcs .'


### PR DESCRIPTION
### Description of the Change

This PR adds in GitHub Actions to help with automation relating to:
- PHPCS linting (eslint and other linting can be added in as desired)
- Deploying plugin releases to WordPress.org
- Deploying minor readme.txt and asset changes to WordPress.org (helpful when bumping the "Tested up to:" value for major WordPress release compatibility testing)

This will require adding [GitHub repository secrets](https://docs.github.com/en/actions/reference/encrypted-secrets) for `SVN_USERNAME` and `SVN_PASSWORD` for an account that has commit access for the plugin on WordPress.org SVN.  I recommend having a company/org account, essentially one NOT linked to a specific person, so that releases/updates can continue without being blocked by a specific person moving off the project.

Most notably the PR does **NOT** add in a [testing action](https://github.com/10up/safe-redirect-manager/blob/develop/.github/workflows/test.yml) given how complex the existing CircleCI integration is.  However getting that test process ported into the sample test action linked just previously would even further reduce tooling dependencies to just GitHub.

I'd similarly recommend a new `develop` branch off `master` that's set as the default branch for the repo and that future releases essentially merges develop into master ([more on that here](https://10up.github.io/Open-Source-Best-Practices/github-process/#branching-merging-deploying)).  Further, I'd recommend to use the [GitHub branch renaming](https://docs.github.com/en/github/administering-a-repository/renaming-a-branch) to rename `master` to something like `trunk` or `main` to avoid using the "master" term.  I'm happy to help scan the repo for places that need branch references updated, just let me know!

### Alternate Designs

Continue to run linting and handle WordPress.org SVN updates elsewhere.

### Benefits

Further automates what can be heavily manual processes, also standardizes all checking/testing/linting to within GitHub to help reduce tooling.

### Possible Drawbacks

None identified.

### Verification Process

Manually verified via VS Code and GitHub Desktop UI.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

none identified

### Changelog Entry

```
### Added
- Plugin linting, releasing, and updating automation via GitHub Actions (props [@jeffpaul](https://github.com/jeffpaul/))
```