### PR TITLE
Fix: Removes initializing entire plugin class structure on delete

### DIFF
--- a/uninstall.php
+++ b/uninstall.php
@@ -11,9 +11,6 @@ if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 	die;
 }
 
-require_once dirname( __FILE__ ) . '/load-files.php';
-
-$wpephpc = new WPEPHPCompat( dirname( __FILE__ ) );
 delete_option( 'wpephpcompat.lock' );
 delete_option( 'wpephpcompat.status' );
 delete_option( 'wpephpcompat.numdirs' );

--- a/uninstall.php
+++ b/uninstall.php
@@ -14,5 +14,23 @@ if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 require_once dirname( __FILE__ ) . '/load-files.php';
 
 $wpephpc = new WPEPHPCompat( dirname( __FILE__ ) );
-$wpephpc->clean_after_scan();
+delete_option( 'wpephpcompat.lock' );
+delete_option( 'wpephpcompat.status' );
+delete_option( 'wpephpcompat.numdirs' );
+
+// Clear scheduled cron.
+wp_clear_scheduled_hook( 'wpephpcompat_start_test_cron' );
+
+// Make sure all directories are removed from the queue.
+$args = array(
+	'posts_per_page' => -1,
+	'post_type'      => 'wpephpcompat_jobs',
+);
+
+$directories = get_posts( $args );
+
+foreach ( $directories as $directory ) {
+	wp_delete_post( $directory->ID );
+}
+
 delete_option( 'wpephpcompat.scan_results' );


### PR DESCRIPTION
Currently the plugin is unable to be deleted on PHP 8 environments. This is due to a number of out of date composer packages that have been held back from updating due to the restructure and loss of features it would entail. We are in progress on refactoring this entire plugin to be future proof, however, at the moment php 8 will remain incompatible with the current structure. This PR allows for php8 environments to delete the plugin without triggering the incompatible code.

To test this, you should be able to clone down the repo to the plugin directory, run composer install, npm install, and view the plugin on the plugins page of wp-admin to initiate a hopefully successful deletion.