### PR TITLE
chore: add `dealerdirect/phpcodesniffer-composer-installer` to `config.allow-plugins`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,5 +19,10 @@
 		"phpcs": "phpcs --standard=src/ruleset-wordpress.xml wpengine-phpcompat.php load-files.php src/*.php",
 		"phpcs:fix": "phpcbf --standard=src/ruleset-wordpress.xml wpengine-phpcompat.php load-files.php src/*.php",
 		"test": "phpunit"
+	},
+	"config": {
+		"allow-plugins": {
+			"dealerdirect/phpcodesniffer-composer-installer": true
+		}
 	}
 }


### PR DESCRIPTION
Addresses test failure caused by Composer config not allowing this plugin.

Example: https://app.circleci.com/pipelines/github/wpengine/phpcompat/123/workflows/6edab353-3798-4642-b1a8-dbb6a2ca0dbb/jobs/608