### PR TITLE
Adds namespace for package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,10 @@
 {
-  "name": "php-compatibility-checker",
+  "name": "@wpengine/php-compatibility-checker",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "php-compatibility-checker",
+      "name": "@wpengine/php-compatibility-checker",
       "devDependencies": {
         "braces": "^2.3.1",
         "chokidar": "^3.5.3",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "php-compatibility-checker",
+  "name": "@wpengine/php-compatibility-checker",
   "devDependencies": {
     "braces": "^2.3.1",
     "chokidar": "^3.5.3",


### PR DESCRIPTION
It was noticed that the namespace was missing from the name which could get confusing to some folks. If this were ever published it would be under @ wpengine so we should probably reflect that in the name of this repo's package.json