### PR TITLE
Fix tar dependency and bump versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,8 +35,7 @@
 				"webpack-bundle-analyzer": "^4.2",
 				"webpack-cli": "^4.6",
 				"webpack-livereload-plugin": "^2.3",
-				"webpack-merge": "^5.8.0",
-				"webpack-node-externals": "^3.0.0"
+				"webpack-merge": "^5.8.0"
 			}
 		},
 		"node_modules/@adobe/css-tools": {
@@ -26713,15 +26712,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/webpack-node-externals": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/webpack-node-externals/-/webpack-node-externals-3.0.0.tgz",
-			"integrity": "sha512-LnL6Z3GGDPht/AigwRh2dvL9PQPFQ8skEpVrWZXLWBYmqcaojHNN0onvHzie6rq7EWKrrBfPYqNEzTJgiwEQDQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=6"
-			}
-		},
 		"node_modules/webpack-sources": {
 			"version": "3.2.3",
 			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
@@ -47387,12 +47377,6 @@
 					}
 				}
 			}
-		},
-		"webpack-node-externals": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/webpack-node-externals/-/webpack-node-externals-3.0.0.tgz",
-			"integrity": "sha512-LnL6Z3GGDPht/AigwRh2dvL9PQPFQ8skEpVrWZXLWBYmqcaojHNN0onvHzie6rq7EWKrrBfPYqNEzTJgiwEQDQ==",
-			"dev": true
 		},
 		"webpack-sources": {
 			"version": "3.2.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
 				"@wordpress/scripts": "^26.2.0",
 				"babel-jest": "^26.0",
 				"babel-loader": "^8.1",
+				"buffer": "^6.0.3",
 				"compare-versions": "^4.1",
 				"ignore-emit-webpack-plugin": "^2.0",
 				"jest": "^26.0",
@@ -34,7 +35,8 @@
 				"webpack-bundle-analyzer": "^4.2",
 				"webpack-cli": "^4.6",
 				"webpack-livereload-plugin": "^2.3",
-				"webpack-merge": "^5.8.0"
+				"webpack-merge": "^5.8.0",
+				"webpack-node-externals": "^3.0.0"
 			}
 		},
 		"node_modules/@adobe/css-tools": {
@@ -8236,6 +8238,30 @@
 				"readable-stream": "^3.4.0"
 			}
 		},
+		"node_modules/bl/node_modules/buffer": {
+			"version": "5.7.1",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+			"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"dependencies": {
+				"base64-js": "^1.3.1",
+				"ieee754": "^1.1.13"
+			}
+		},
 		"node_modules/bl/node_modules/readable-stream": {
 			"version": "3.6.2",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
@@ -8430,9 +8456,9 @@
 			}
 		},
 		"node_modules/buffer": {
-			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-			"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
 			"dev": true,
 			"funding": [
 				{
@@ -8450,7 +8476,7 @@
 			],
 			"dependencies": {
 				"base64-js": "^1.3.1",
-				"ieee754": "^1.1.13"
+				"ieee754": "^1.2.1"
 			}
 		},
 		"node_modules/buffer-crc32": {
@@ -25716,6 +25742,30 @@
 				"through": "^2.3.8"
 			}
 		},
+		"node_modules/unbzip2-stream/node_modules/buffer": {
+			"version": "5.7.1",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+			"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"dependencies": {
+				"base64-js": "^1.3.1",
+				"ieee754": "^1.1.13"
+			}
+		},
 		"node_modules/unicode-canonical-property-names-ecmascript": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.0.tgz",
@@ -26661,6 +26711,15 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/webpack-node-externals": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/webpack-node-externals/-/webpack-node-externals-3.0.0.tgz",
+			"integrity": "sha512-LnL6Z3GGDPht/AigwRh2dvL9PQPFQ8skEpVrWZXLWBYmqcaojHNN0onvHzie6rq7EWKrrBfPYqNEzTJgiwEQDQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/webpack-sources": {
@@ -33214,6 +33273,16 @@
 				"readable-stream": "^3.4.0"
 			},
 			"dependencies": {
+				"buffer": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+					"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+					"dev": true,
+					"requires": {
+						"base64-js": "^1.3.1",
+						"ieee754": "^1.1.13"
+					}
+				},
 				"readable-stream": {
 					"version": "3.6.2",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
@@ -33379,13 +33448,13 @@
 			}
 		},
 		"buffer": {
-			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-			"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
 			"dev": true,
 			"requires": {
 				"base64-js": "^1.3.1",
-				"ieee754": "^1.1.13"
+				"ieee754": "^1.2.1"
 			}
 		},
 		"buffer-crc32": {
@@ -46558,6 +46627,18 @@
 			"requires": {
 				"buffer": "^5.2.1",
 				"through": "^2.3.8"
+			},
+			"dependencies": {
+				"buffer": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+					"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+					"dev": true,
+					"requires": {
+						"base64-js": "^1.3.1",
+						"ieee754": "^1.1.13"
+					}
+				}
 			}
 		},
 		"unicode-canonical-property-names-ecmascript": {
@@ -47306,6 +47387,12 @@
 					}
 				}
 			}
+		},
+		"webpack-node-externals": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/webpack-node-externals/-/webpack-node-externals-3.0.0.tgz",
+			"integrity": "sha512-LnL6Z3GGDPht/AigwRh2dvL9PQPFQ8skEpVrWZXLWBYmqcaojHNN0onvHzie6rq7EWKrrBfPYqNEzTJgiwEQDQ==",
+			"dev": true
 		},
 		"webpack-sources": {
 			"version": "3.2.3",

--- a/package.json
+++ b/package.json
@@ -47,8 +47,7 @@
 		"webpack-bundle-analyzer": "^4.2",
 		"webpack-cli": "^4.6",
 		"webpack-livereload-plugin": "^2.3",
-		"webpack-merge": "^5.8.0",
-		"webpack-node-externals": "^3.0.0"
+		"webpack-merge": "^5.8.0"
 	},
 	"dependencies": {
 		"@wordpress/env": "^5.16.0",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
 		"@wordpress/scripts": "^26.2.0",
 		"babel-jest": "^26.0",
 		"babel-loader": "^8.1",
+		"buffer": "^6.0.3",
 		"compare-versions": "^4.1",
 		"ignore-emit-webpack-plugin": "^2.0",
 		"jest": "^26.0",
@@ -46,7 +47,8 @@
 		"webpack-bundle-analyzer": "^4.2",
 		"webpack-cli": "^4.6",
 		"webpack-livereload-plugin": "^2.3",
-		"webpack-merge": "^5.8.0"
+		"webpack-merge": "^5.8.0",
+		"webpack-node-externals": "^3.0.0"
 	},
 	"dependencies": {
 		"@wordpress/env": "^5.16.0",

--- a/plugin/wpengine-phpcompat.php
+++ b/plugin/wpengine-phpcompat.php
@@ -3,7 +3,7 @@
  * Plugin Name:       PHP Compatibility Checker
  * Plugin URI:        https://wpengine.com
  * Description:       The WP Engine PHP Compatibility Checker can be used by any WordPress website on any web host to check PHP version compatibility.
- * Version:           1.6.2
+ * Version:           1.6.3
  * Requires at least: 5.6
  * Requires PHP:      5.6
  * Author:            WP Engine

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors:      wpengine, octalmage, stevenkword, Taylor4484, pross, jcross, rfmeier, cadic, dkotter, ankit-k-gupta, jeffpaul
 Tags:              php 7, php 8, php, version, compat, compatibility, checker, wp engine, wpe, wpengine
 Requires at least: 5.6
-Tested up to:      6.2
-Stable tag:        1.6.2
+Tested up to:      6.4
+Stable tag:        1.6.3
 License:           GPLv2 or later
 License URI:       http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -87,6 +87,9 @@ You will find the plugin options in the WP Admin `Tools => PHP Compatibility` me
 2. Compatibility results screen
 
 == Changelog ==
+= 1.6.3 =
+Fix issue where Buffer was not available to the scans.
+
 = 1.6.2 =
 - Update packages.
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,6 +2,7 @@ const { merge } = require("webpack-merge");
 const defaultConfig = require("@wordpress/scripts/config/webpack.config");
 const DependencyExtractionWebpackPlugin = require("@wordpress/dependency-extraction-webpack-plugin");
 const path = require("path");
+const webpack = require('webpack');
 
 module.exports = merge(defaultConfig, {
   output: {
@@ -16,5 +17,13 @@ module.exports = merge(defaultConfig, {
         plugin.constructor.name !== "DependencyExtractionWebpackPlugin"
     ),
     new DependencyExtractionWebpackPlugin(),
-  ]
+    new webpack.ProvidePlugin({
+      Buffer: ['buffer', 'Buffer'],
+    }),
+  ],
+  resolve: {
+    fallback: {
+      buffer: require.resolve("buffer/"),
+    }
+  }
 });


### PR DESCRIPTION
This fixes the issue with Tar versions by updating the terser-webpack-plugin which removes the dependency completely.

This does not require a deploy as these changes are already live on wordpress.org